### PR TITLE
Reenable deploy script inclusion on master

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -49,4 +49,4 @@ dependencies {
   testCompile 'junit:junit:4.12'
 }
 // TODO: fix path when included as submodule
-//apply from: "$rootDir/gradle/artifact-deploy.gradle"
+apply from: "$rootDir/gradle/artifact-deploy.gradle"

--- a/researchstack-sdk/build.gradle
+++ b/researchstack-sdk/build.gradle
@@ -63,4 +63,4 @@ dependencies {
   testCompile 'org.mockito:mockito-core:1.10.19'
 }
 // TODO: fix path when included as submodule
-//apply from: "$rootDir/gradle/artifact-deploy.gradle"
+apply from: "$rootDir/gradle/artifact-deploy.gradle"


### PR DESCRIPTION
This will allow master branch to deploy artifact to binTray.

develop will still have these scripts commented out to play nicely with mPower-Android, which is including this repo as a submodule
develop will not deploy due to .travis.yml