### PR TITLE
Client-Side Surveys (matched by taskID)

### DIFF
--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/TaskHelper.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/TaskHelper.java
@@ -183,18 +183,12 @@ public class TaskHelper {
                     });
         } else {
             // Does the taskID match one of our local resources?
-            taskModelSingle = Single.fromCallable(() -> {
-                // There doesn't seem to be a way to check for file existence before we attempt to
-                // open it. If the file exists, it'll throw a FileNotFoundException wrapped in a
-                // RuntimeException. Wrap in a try catch.
-                try {
-                    return resourceManager.getTask(task.taskID).create(context);
-                } catch (RuntimeException ex) {
-                    // Return null. This signals to the ActivitiesFragment that we can't load the
+            taskModelSingle = Single.fromCallable(() -> (TaskModel) resourceManager
+                    .getTask(task.taskID).create(context))
+                    // If creating the task fails (generally because it's not a file-based survey,
+                    // return null. This signals to the ActivitiesFragment that we can't load the
                     // survey either from server or file, and that it's probably a custom task.
-                    return null;
-                }
-            });
+                    .onErrorReturn(throwable -> null);
         }
 
         return taskModelSingle.map(taskModel -> {


### PR DESCRIPTION
Hooked up Client-Side Surveys to the task helper.

Testing done:
* ./gradlew check
* Added a test client-side survey to CRF Module and manually tested.
* For good measure, also tested server-side survey (Usability Survey) and non-survey (Heart Rate Measurement).