### PR TITLE
data groups in onboarding

### DIFF
--- a/android-sdk/src/main/java/org/sagebionetworks/bridge/android/manager/dao/AccountDAO.java
+++ b/android-sdk/src/main/java/org/sagebionetworks/bridge/android/manager/dao/AccountDAO.java
@@ -2,24 +2,67 @@ package org.sagebionetworks.bridge.android.manager.dao;
 
 import android.content.Context;
 import android.support.annotation.AnyThread;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.google.gson.reflect.TypeToken;
 import org.sagebionetworks.bridge.rest.model.SignIn;
 import org.sagebionetworks.bridge.rest.model.StudyParticipant;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by jyliu on 2/8/2017.
  */
 @AnyThread
 public class AccountDAO extends SharedPreferencesJsonDAO {
+    private static final TypeToken<List<String>> STRING_LIST = new TypeToken<List<String>>(){};
+
     private static final String PREFERENCES_FILE  = "accounts";
+    private static final String KEY_DATA_GROUPS = "dataGroups";
     private static final String KEY_SESSION_INFO = "session";
     private static final String KEY_STUDY_PARTICIPANT = "participant";
     private static final String KEY_SIGN_IN = "signIn";
 
     public AccountDAO(Context applicationContext) {
         super(applicationContext, PREFERENCES_FILE);
+    }
+
+    /**
+     * Returns a list of data groups associated with this account. If there are no data groups,
+     * this method returns an empty list.
+     */
+    @NonNull
+    public List<String> getDataGroups() {
+        List<String> rawDataGroupList = getValue(KEY_DATA_GROUPS, STRING_LIST);
+        if (rawDataGroupList == null) {
+            // Null collections are bad. Return an empty list. Make it mutable, because callers
+            // might want to update it.
+            return new ArrayList<>();
+        } else {
+            return rawDataGroupList;
+        }
+    }
+
+    /**
+     * Sets data groups for this account locally. Note: this does not call the server to update the
+     * participant. Note: this replaces existing data groups. To add to existing data groups, call
+     * addDataGroup().
+     */
+    public void setDataGroups(@NonNull List<String> dataGroupList) {
+        setValue(KEY_DATA_GROUPS, dataGroupList, STRING_LIST);
+    }
+
+    /**
+     * Add data groups to this account locally. Note: this does not call the server to update the
+     * participant.
+     */
+    public void addDataGroup(@NonNull String dataGroup) {
+        List<String> dataGroupList = getDataGroups();
+        dataGroupList.add(dataGroup);
+        setDataGroups(dataGroupList);
     }
 
     @Nullable

--- a/android-sdk/src/test/java/org/sagebionetworks/bridge/android/manager/dao/AccountDAOTest.java
+++ b/android-sdk/src/test/java/org/sagebionetworks/bridge/android/manager/dao/AccountDAOTest.java
@@ -1,0 +1,56 @@
+/*
+ *    Copyright 2017 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebionetworks.bridge.android.manager.dao;
+
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.sagebionetworks.bridge.android.BuildConfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Config(constants = BuildConfig.class)
+@RunWith(RobolectricTestRunner.class)
+public class AccountDAOTest {
+    private AccountDAO accountDAO;
+
+    @Before
+    public void setup() {
+        accountDAO = new AccountDAO(RuntimeEnvironment.application);
+    }
+
+    @Test
+    public void dataGroups() {
+        // Data Groups is initially empty.
+        assertTrue(accountDAO.getDataGroups().isEmpty());
+
+        // Add data groups and verify.
+        accountDAO.addDataGroup("foo");
+        accountDAO.addDataGroup("bar");
+        assertEquals(Lists.newArrayList("foo", "bar"), accountDAO.getDataGroups());
+
+        // Set data groups and verify.
+        accountDAO.setDataGroups(Lists.newArrayList("asdf", "jkl"));
+        assertEquals(Lists.newArrayList("asdf", "jkl"), accountDAO.getDataGroups());
+    }
+}

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
@@ -456,6 +456,27 @@ public abstract class BridgeDataProvider extends DataProvider {
 
     //endregion
 
+    // region Data Groups
+
+    /**
+     * Add data groups to this account locally. Note: this does not call the server to update the
+     * participant.
+     */
+    public void addLocalDataGroup(@NonNull String dataGroup) {
+        bridgeManagerProvider.getAccountDao().addDataGroup(dataGroup);
+    }
+
+    /**
+     * Returns a list of data groups associated with this account. If there are no data groups,
+     * this method returns an empty list.
+     */
+    @NonNull
+    public List<String> getDataGroups() {
+        return bridgeManagerProvider.getAccountDao().getDataGroups();
+    }
+
+    // endregion Data Groups
+
     //region User
 
     @Override

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/onboarding/BridgeOnboardingManager.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/onboarding/BridgeOnboardingManager.java
@@ -1,0 +1,85 @@
+/*
+ *    Copyright 2017 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebionetworks.bridge.researchstack.onboarding;
+
+import android.content.Context;
+import org.researchstack.backbone.answerformat.AnswerFormat;
+import org.researchstack.backbone.answerformat.ChoiceAnswerFormat;
+import org.researchstack.backbone.model.Choice;
+import org.researchstack.backbone.model.survey.SurveyItem;
+import org.researchstack.backbone.model.survey.factory.SurveyFactory;
+import org.researchstack.backbone.onboarding.OnboardingManager;
+import org.researchstack.backbone.step.Step;
+import org.sagebionetworks.bridge.researchstack.step.DataGroupQuestionStep;
+import org.sagebionetworks.bridge.researchstack.survey.DataGroupQuestionSurveyItem;
+
+/**
+ * BridgeOnboardingManager overrides createCustomStep() to enable Bridge-specific Onboarding steps,
+ * such as data group settings based on onboarding questions. Apps that want these features should
+ * subclass BridgeOnboardingManager instead of OnboardingManager.
+ */
+public class BridgeOnboardingManager extends OnboardingManager {
+    /**
+     * Initializes the BridgeOnboardingManager and the superclass based on the provided context.
+     *
+     * @param context used in reference to the ResourceManager to load JSON resources to construct
+     *                the onboarding manager
+     */
+    public BridgeOnboardingManager(Context context) {
+        super(context);
+    }
+
+    /** Create custom onboarding steps for Bridge. */
+    @Override
+    public Step createCustomStep(
+            Context context, SurveyItem item, boolean isSubtaskStep, SurveyFactory factory) {
+        if (DataGroupQuestionSurveyItem.CUSTOM_TYPE.equals(item.getCustomTypeValue())) {
+            // Basic validation
+            if (!(item instanceof DataGroupQuestionSurveyItem)) {
+                throw new IllegalStateException("Error in json parsing, this type must be " +
+                        "DataGroupQuestionSurveyItem");
+            }
+            DataGroupQuestionSurveyItem dataGroupItem = (DataGroupQuestionSurveyItem) item;
+            if (dataGroupItem.items == null || dataGroupItem.items.isEmpty()) {
+                throw new IllegalStateException("DataGroupQuestionSurveyItem must have choices");
+            }
+
+            // Create answer format for this question
+            AnswerFormat.ChoiceAnswerStyle answerStyle = AnswerFormat.ChoiceAnswerStyle
+                    .SingleChoice;
+            Choice[] choices = dataGroupItem.items.toArray(new Choice[dataGroupItem.items.size()]);
+            AnswerFormat format = new ChoiceAnswerFormat(answerStyle, choices);
+
+            // Create the question step and apply navigation rules
+            DataGroupQuestionStep dataGroupStep = new DataGroupQuestionStep(
+                    dataGroupItem.identifier, dataGroupItem.title, format);
+            dataGroupStep.setExpectedAnswer(dataGroupItem.expectedAnswer);
+            dataGroupStep.setOptional(dataGroupItem.optional);
+            dataGroupStep.setPlaceholder(dataGroupItem.placeholderText);
+            dataGroupStep.setShouldPersist(dataGroupItem.shouldPersist());
+            dataGroupStep.setSkipToStepIdentifier(dataGroupItem.skipIdentifier);
+            dataGroupStep.setSkipIfPassed(dataGroupItem.skipIfPassed);
+            dataGroupStep.setText(dataGroupItem.text);
+
+            return dataGroupStep;
+        } else {
+            // For everything else, fallback to the superclass's createCustomStep.
+            return super.createCustomStep(context, item, isSubtaskStep, factory);
+        }
+    }
+}

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/step/DataGroupQuestionStep.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/step/DataGroupQuestionStep.java
@@ -1,0 +1,62 @@
+/*
+ *    Copyright 2017 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebionetworks.bridge.researchstack.step;
+
+import org.researchstack.backbone.answerformat.AnswerFormat;
+import org.researchstack.backbone.step.NavigationExpectedAnswerQuestionStep;
+import org.sagebionetworks.bridge.researchstack.step.layout.DataGroupQuestionStepLayout;
+
+/**
+ * Data group question step, used to determine which data groups should apply to a user during
+ * onboarding.
+ */
+public class DataGroupQuestionStep extends NavigationExpectedAnswerQuestionStep {
+    private boolean shouldPersist = false;
+
+    /**
+     * Constructs the DataGroupQuestionStep
+     *
+     * @param identifier The identifier of the step (a step identifier should be unique within the
+     *                   task).
+     * @param title      A localized string that represents the primary text of the question.
+     * @param format     The format in which the answer is expected.
+     */
+    public DataGroupQuestionStep(String identifier, String title, AnswerFormat format) {
+        super(identifier, title, format);
+    }
+
+    /**
+     * True if this should write all local data groups to Bridge Server. False if it should merely
+     * save the question result to local storage. This is used if there are multiple questions
+     * setting multiple data groups, so we make one server call instead of multiple.
+     */
+    public boolean shouldPersist() {
+        return shouldPersist;
+    }
+
+    /** @see #shouldPersist */
+    public void setShouldPersist(boolean shouldPersist) {
+        this.shouldPersist = shouldPersist;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Class getStepLayoutClass() {
+        return DataGroupQuestionStepLayout.class;
+    }
+}

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/step/layout/DataGroupQuestionStepLayout.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/step/layout/DataGroupQuestionStepLayout.java
@@ -1,0 +1,116 @@
+/*
+ *    Copyright 2017 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebionetworks.bridge.researchstack.step.layout;
+
+import android.content.Context;
+import android.support.annotation.VisibleForTesting;
+import android.util.AttributeSet;
+import org.researchstack.backbone.DataProvider;
+import org.researchstack.backbone.DataResponse;
+import org.researchstack.backbone.ui.step.layout.SurveyStepLayout;
+import org.researchstack.backbone.utils.StepLayoutHelper;
+import org.sagebionetworks.bridge.researchstack.ApiUtils;
+import org.sagebionetworks.bridge.researchstack.BridgeDataProvider;
+import org.sagebionetworks.bridge.researchstack.step.DataGroupQuestionStep;
+import org.sagebionetworks.bridge.rest.model.StudyParticipant;
+import rx.Observable;
+
+import java.util.List;
+
+/**
+ * Encapsulates the logic for the DataGroupQuestionStep, specifically storing the data group locally
+ * and submitting it to the server if the shouldPersist flag is true.
+ */
+public class DataGroupQuestionStepLayout extends SurveyStepLayout {
+    /** Required constructor */
+    public DataGroupQuestionStepLayout(Context context) {
+        super(context);
+    }
+
+    /** Required constructor */
+    public DataGroupQuestionStepLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    /** Required constructor */
+    public DataGroupQuestionStepLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    /**
+     * Called when the step is completed (not skipped) and the results are valid. This will store
+     * the data group locally and submit to the server if the shouldPersist flag is true.
+     */
+    @Override
+    protected void onComplete() {
+        BridgeDataProvider dataProvider = (BridgeDataProvider) DataProvider.getInstance();
+
+        // Save the data group locally. If specified.
+        Object rawDataGroup = getRawDataGroupResult();
+        if (rawDataGroup != null) {
+            String dataGroup = rawDataGroup.toString();
+            if (!dataGroup.isEmpty()) {
+                dataProvider.addLocalDataGroup(dataGroup);
+            }
+        }
+
+        // Persist data groups to server, if this step says we should.
+        boolean shouldPersist = ((DataGroupQuestionStep) getStep()).shouldPersist();
+        if (shouldPersist) {
+            showLoadingDialog();
+
+            // Update Participant API merges the participant we send up with the participant stored
+            // in the server. Thus, it's safe to send a participant with just data groups.
+            List<String> dataGroupList = dataProvider.getDataGroups();
+            StudyParticipant updatedParticipant = new StudyParticipant();
+            updatedParticipant.setDataGroups(dataGroupList);
+            Observable<DataResponse> updateObservable = dataProvider
+                    .updateStudyParticipant(updatedParticipant).toCompletable()
+                    .andThen(ApiUtils.SUCCESS_DATA_RESPONSE);
+
+            StepLayoutHelper.safePerform(updateObservable, this,
+                    new StepLayoutHelper.WebCallback() {
+                        @Override
+                        public void onSuccess(DataResponse response) {
+                            hideLoadingDialog();
+                            // Call super.onComplete() to handle the state transition.
+                            superOnCompleteWrapper();
+                        }
+
+                        @Override
+                        public void onFail(Throwable throwable) {
+                            hideLoadingDialog();
+                            showOkAlertDialog(throwable.getMessage());
+                        }
+                    });
+        } else {
+            // Call super.onComplete() to handle the state transition.
+            superOnCompleteWrapper();
+        }
+    }
+
+    @VisibleForTesting
+    void superOnCompleteWrapper() {
+        super.onComplete();
+    }
+
+    @VisibleForTesting
+    Object getRawDataGroupResult() {
+        return stepBody.getStepResult(false).getResult();
+    }
+}

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/survey/DataGroupQuestionSurveyItem.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/survey/DataGroupQuestionSurveyItem.java
@@ -1,0 +1,53 @@
+/*
+ *    Copyright 2017 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebionetworks.bridge.researchstack.survey;
+
+import android.support.annotation.VisibleForTesting;
+import org.researchstack.backbone.model.Choice;
+import org.researchstack.backbone.model.survey.QuestionSurveyItem;
+
+/**
+ * Data group question item, used to determine which data groups should apply to a user during
+ * onboarding.
+ */
+public class DataGroupQuestionSurveyItem  extends QuestionSurveyItem<Choice<String>> {
+    /** Custom type identifier. */
+    public static final String CUSTOM_TYPE = "dataGroups.singleChoiceText";
+
+    private boolean shouldPersist;
+
+    @Override
+    @VisibleForTesting
+    public void setCustomTypeValue(String value) {
+        super.setCustomTypeValue(value);
+    }
+
+    /**
+     * True if this should write all local data groups to Bridge Server. False if it should merely
+     * save the question result to local storage. This is used if there are multiple questions
+     * setting multiple data groups, so we make one server call instead of multiple.
+     */
+    public boolean shouldPersist() {
+        return shouldPersist;
+    }
+
+    /** @see #shouldPersist */
+    public void setShouldPersist(boolean shouldPersist) {
+        this.shouldPersist = shouldPersist;
+    }
+}

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/task/creation/BridgeSurveyItemAdapter.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/task/creation/BridgeSurveyItemAdapter.java
@@ -1,29 +1,36 @@
 package org.sagebionetworks.bridge.researchstack.task.creation;
 
+import android.support.annotation.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 
 import org.researchstack.backbone.model.survey.CompoundQuestionSurveyItem;
 import org.researchstack.backbone.model.survey.SurveyItem;
 import org.researchstack.backbone.model.survey.SurveyItemAdapter;
+import org.sagebionetworks.bridge.researchstack.survey.DataGroupQuestionSurveyItem;
 
-/**
- * Created by TheMDP on 3/25/17.
- */
+import java.util.Map;
 
+/** Subclasses SurveyItemAdapter to enable custom survey and onboarding question types. */
 public class BridgeSurveyItemAdapter extends SurveyItemAdapter {
 
+    // iOS had this one be the only "type" custom one, the rest are normal supported types,
+    // but with additional json fields, which we will deal with in CustomStepCreation
     public static final String TRACKED_SELECTION_TYPE_GSON = "trackingSelection";
+
+    @VisibleForTesting
+    static final Map<String, Class<? extends SurveyItem>> TYPE_TO_CLASS =
+            ImmutableMap.<String, Class<? extends SurveyItem>>builder()
+                    .put(DataGroupQuestionSurveyItem.CUSTOM_TYPE, DataGroupQuestionSurveyItem.class)
+                    .put(TRACKED_SELECTION_TYPE_GSON, CompoundQuestionSurveyItem.class)
+                    .build();
 
     @Override
     public Class<? extends SurveyItem> getCustomClass(String customType, JsonElement json) {
-
-        // iOS had this one be the only "type" custom one, the rest are normal supported types,
-        // but with additional json fields, which we will deal with in CustomStepCreation
-        switch (customType) {
-            case TRACKED_SELECTION_TYPE_GSON:
-                return CompoundQuestionSurveyItem.class;
+        if (customType != null && TYPE_TO_CLASS.containsKey(customType)) {
+            return TYPE_TO_CLASS.get(customType);
+        } else {
+            return super.getCustomClass(customType, json);
         }
-
-        return super.getCustomClass(customType, json);
     }
 }

--- a/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/BridgeDataProviderTest.java
+++ b/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/BridgeDataProviderTest.java
@@ -6,6 +6,7 @@ import android.preference.PreferenceManager;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Before;
@@ -558,6 +559,19 @@ public class BridgeDataProviderTest {
         dataProvider.forgotPassword(context, "email").test().assertCompleted();
 
         verify(authenticationManager).requestPasswordReset("email");
+    }
+
+    @Test
+    public void testAddDataGroup() {
+        ((BridgeDataProvider) dataProvider).addLocalDataGroup("foo");
+        verify(accountDAO).addDataGroup("foo");
+    }
+
+    @Test
+    public void testGetDataGroups() {
+        when(accountDAO.getDataGroups()).thenReturn(Lists.newArrayList("foo", "bar"));
+        List<String> dataGroupList = ((BridgeDataProvider) dataProvider).getDataGroups();
+        assertEquals(Lists.newArrayList("foo", "bar"), dataGroupList);
     }
 
     private static TaskResult makeActivityTask(String taskId) {

--- a/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/onboarding/BridgeOnboardingManagerTest.java
+++ b/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/onboarding/BridgeOnboardingManagerTest.java
@@ -1,0 +1,92 @@
+/*
+ *    Copyright 2017 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebionetworks.bridge.researchstack.onboarding;
+
+import android.content.Context;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.researchstack.backbone.answerformat.AnswerFormat;
+import org.researchstack.backbone.answerformat.ChoiceAnswerFormat;
+import org.researchstack.backbone.model.Choice;
+import org.researchstack.backbone.model.survey.SurveyItemType;
+import org.researchstack.backbone.model.survey.factory.SurveyFactory;
+import org.sagebionetworks.bridge.researchstack.step.DataGroupQuestionStep;
+import org.sagebionetworks.bridge.researchstack.survey.DataGroupQuestionSurveyItem;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BridgeOnboardingManagerTest {
+    @Test
+    public void createCustomStep_DataGroupQuestionStep() {
+        // Constructing an OnboardingManager is kinda hairy. Just mock it, and then set
+        // createCustomStep() to call through to the real method.
+        BridgeOnboardingManager bridgeOnboardingManager = mock(BridgeOnboardingManager.class);
+        when(bridgeOnboardingManager.createCustomStep(any(), any(), anyBoolean(), any()))
+                .thenCallRealMethod();
+
+        // We don't use Context or SurveyFactory (or isSubtaskStep), but mock them anyway.
+        Context mockContext = mock(Context.class);
+        SurveyFactory mockSurveyFactory = mock(SurveyFactory.class);
+
+        // Make choices
+        List<Choice<String>> choiceList = ImmutableList.of(
+                new Choice<>("Choose Foo", "foo"),
+                new Choice<>("Choose Bar", "bar"));
+
+        // Make survey item
+        DataGroupQuestionSurveyItem item = new DataGroupQuestionSurveyItem();
+        item.setCustomTypeValue(DataGroupQuestionSurveyItem.CUSTOM_TYPE);
+        item.expectedAnswer = "foo";
+        item.identifier = "my-item-id";
+        item.items = choiceList;
+        item.optional = true;
+        item.placeholderText = "My Placeholder Text";
+        item.setShouldPersist(true);
+        item.skipIdentifier = "next-question-id";
+        item.skipIfPassed = true;
+        item.text = "My Onboarding Item Text";
+        item.title = "My Onboarding Item";
+        item.type = SurveyItemType.CUSTOM;
+
+        // Execute and validate
+        DataGroupQuestionStep step = (DataGroupQuestionStep) bridgeOnboardingManager
+                .createCustomStep(mockContext, item, true, mockSurveyFactory);
+        assertEquals(item.expectedAnswer, step.getExpectedAnswer());
+        assertEquals(item.identifier, step.getIdentifier());
+        assertEquals(item.optional, step.isOptional());
+        assertEquals(item.placeholderText, step.getPlaceholder());
+        assertEquals(item.shouldPersist(), step.shouldPersist());
+        assertEquals(item.skipIdentifier, step.getSkipToStepIdentifier());
+        assertEquals(item.skipIfPassed, step.getSkipIfPassed());
+        assertEquals(item.text, step.getText());
+        assertEquals(item.title, step.getTitle());
+
+        ChoiceAnswerFormat answerFormat = (ChoiceAnswerFormat) step.getAnswerFormat();
+        assertEquals(AnswerFormat.Type.SingleChoice, answerFormat.getQuestionType());
+        Choice[] choiceArray = answerFormat.getChoices();
+        assertEquals(2, choiceArray.length);
+        assertEquals(choiceList.get(0), choiceArray[0]);
+        assertEquals(choiceList.get(1), choiceArray[1]);
+    }
+}

--- a/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/step/layout/DataGroupQuestionStepLayoutTest.java
+++ b/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/step/layout/DataGroupQuestionStepLayoutTest.java
@@ -1,0 +1,186 @@
+/*
+ *    Copyright 2017 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebionetworks.bridge.researchstack.step.layout;
+
+import com.google.common.collect.Lists;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.researchstack.backbone.DataProvider;
+import org.researchstack.backbone.DataResponse;
+import org.researchstack.backbone.utils.StepLayoutHelper;
+import org.sagebionetworks.bridge.researchstack.BridgeDataProvider;
+import org.sagebionetworks.bridge.researchstack.step.DataGroupQuestionStep;
+import org.sagebionetworks.bridge.rest.model.StudyParticipant;
+import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
+import rx.Completable;
+import rx.Observable;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+@PrepareForTest({Completable.class, StepLayoutHelper.class})
+@RunWith(PowerMockRunner.class)
+@SuppressWarnings("unchecked")
+public class DataGroupQuestionStepLayoutTest {
+    private static final String DATA_GROUP = "my_data_group";
+
+    private BridgeDataProvider mockDataProvider;
+    private DataGroupQuestionStep mockStep;
+    private DataGroupQuestionStepLayout stepLayout;
+
+    @Before
+    public void setup() {
+        // Use PowerMock to mock StepLayoutHelper
+        mockStatic(StepLayoutHelper.class);
+
+        // Mock DataProvider.
+        mockDataProvider = mock(BridgeDataProvider.class);
+        DataProvider.init(mockDataProvider);
+
+        // Mock step
+        mockStep = mock(DataGroupQuestionStep.class);
+
+        // Step layouts are hairy to construct. Easier to just mock them and use callRealMethod().
+        stepLayout = mock(DataGroupQuestionStepLayout.class);
+        when(stepLayout.getStep()).thenReturn(mockStep);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        // De-init DataProvider, so that it doesn't interfere with other tests.
+        DataProvider.init(null);
+    }
+
+    @Test
+    public void onComplete_NullDataGroup() {
+        // Setup mocks for step and layout
+        when(mockStep.shouldPersist()).thenReturn(false);
+
+        when(stepLayout.getRawDataGroupResult()).thenReturn(null);
+        doCallRealMethod().when(stepLayout).onComplete();
+
+        // Execute
+        stepLayout.onComplete();
+
+        // Verify dependencies
+        verify(mockDataProvider, never()).addLocalDataGroup(any());
+        verify(mockDataProvider, never()).updateStudyParticipant(any());
+        verify(stepLayout).superOnCompleteWrapper();
+
+        verifyStatic(never());
+        StepLayoutHelper.safePerform(any(), any(), any());
+    }
+
+    @Test
+    public void onComplete_EmptyDataGroup() {
+        // Setup mocks for step and layout
+        when(mockStep.shouldPersist()).thenReturn(false);
+
+        when(stepLayout.getRawDataGroupResult()).thenReturn("");
+        doCallRealMethod().when(stepLayout).onComplete();
+
+        // Execute
+        stepLayout.onComplete();
+
+        // Verify dependencies
+        verify(mockDataProvider, never()).addLocalDataGroup(any());
+        verify(mockDataProvider, never()).updateStudyParticipant(any());
+        verify(stepLayout).superOnCompleteWrapper();
+
+        verifyStatic(never());
+        StepLayoutHelper.safePerform(any(), any(), any());
+    }
+
+    @Test
+    public void onComplete_ShouldPersistFalse() {
+        // Setup mocks for step and layout
+        when(mockStep.shouldPersist()).thenReturn(false);
+
+        when(stepLayout.getRawDataGroupResult()).thenReturn(DATA_GROUP);
+        doCallRealMethod().when(stepLayout).onComplete();
+
+        // Execute
+        stepLayout.onComplete();
+
+        // Verify dependencies
+        verify(mockDataProvider).addLocalDataGroup(DATA_GROUP);
+        verify(mockDataProvider, never()).updateStudyParticipant(any());
+        verify(stepLayout).superOnCompleteWrapper();
+
+        verifyStatic(never());
+        StepLayoutHelper.safePerform(any(), any(), any());
+    }
+
+    @Test
+    public void onComplete_ShouldPersistTrue() {
+        // Setup mocks for step and layout
+        when(mockStep.shouldPersist()).thenReturn(true);
+
+        when(stepLayout.getRawDataGroupResult()).thenReturn(DATA_GROUP);
+        doCallRealMethod().when(stepLayout).onComplete();
+
+        // Mock data provider
+        List<String> dataGroupList = Lists.newArrayList("foo", "bar", DATA_GROUP);
+        when(mockDataProvider.getDataGroups()).thenReturn(dataGroupList);
+
+        Observable<DataResponse> mockDataResponseObservable = Observable.empty();
+
+        // Need to use PowerMock to mock Completable.andThen() because it's final.
+        Completable mockCompletable = PowerMockito.mock(Completable.class);
+        PowerMockito.doReturn(mockDataResponseObservable).when(mockCompletable).andThen(
+                any(Observable.class));
+
+        Observable<UserSessionInfo> mockUpdateObservable = mock(Observable.class);
+        when(mockUpdateObservable.toCompletable()).thenReturn(mockCompletable);
+        when(mockDataProvider.updateStudyParticipant(any())).thenReturn(mockUpdateObservable);
+
+        // Execute
+        stepLayout.onComplete();
+
+        // Verify dependencies
+        verify(mockDataProvider).addLocalDataGroup(DATA_GROUP);
+
+        ArgumentCaptor<StudyParticipant> participantCaptor = ArgumentCaptor.forClass(
+                StudyParticipant.class);
+        verify(mockDataProvider).updateStudyParticipant(participantCaptor.capture());
+        StudyParticipant participant = participantCaptor.getValue();
+        assertEquals(dataGroupList, participant.getDataGroups());
+
+        verifyStatic();
+        StepLayoutHelper.safePerform(same(mockDataResponseObservable), any(), any());
+
+        // superOnCompleteWrapper() is called inside StepLayouHelper.safePerform(), which is mocked,
+        // so the callback is never actually called.
+    }
+}

--- a/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/task/creation/BridgeSurveyItemAdapterTest.java
+++ b/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/task/creation/BridgeSurveyItemAdapterTest.java
@@ -1,0 +1,48 @@
+/*
+ *    Copyright 2017 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebionetworks.bridge.researchstack.task.creation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+import org.researchstack.backbone.model.survey.BaseSurveyItem;
+import org.researchstack.backbone.model.survey.SurveyItem;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class BridgeSurveyItemAdapterTest {
+    @Test
+    public void getCustomClass() {
+        BridgeSurveyItemAdapter adapter = new BridgeSurveyItemAdapter();
+
+        // JSON doesn't matter for this class
+        JsonElement json = new JsonObject();
+
+        // Survey adapter is data driven. Make sure the class output matches the map.
+        for (Map.Entry<String, Class<? extends SurveyItem>> oneEntry :
+                BridgeSurveyItemAdapter.TYPE_TO_CLASS.entrySet()) {
+            assertEquals(oneEntry.getValue(), adapter.getCustomClass(oneEntry.getKey(), json));
+        }
+
+        // Nulls and unrecognized fields call through to the super class
+        assertEquals(BaseSurveyItem.class, adapter.getCustomClass(null, json));
+        assertEquals(BaseSurveyItem.class, adapter.getCustomClass("something else", json));
+    }
+}


### PR DESCRIPTION
Add the data group step to onboarding. See https://sagebionetworks.jira.com/browse/AA-78

Testing done:
* ./gradlew check
* Manually tested both test_user and participant branches.
* Set a breakpoint to verify we only save data groups at the last step, rather than a separate server call each step.