### PR TITLE
Feature/AA-183

### DIFF
--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    api 'org.sagebionetworks.bridge:rest-client:0.13.20', {
+    api 'org.sagebionetworks.bridge:rest-client:0.13.30', {
         exclude group: 'joda-time', module: 'joda-time'
     }
     api 'org.sagebionetworks:BridgeDataUploadUtils:0.2.3', {

--- a/android-sdk/src/main/java/org/sagebionetworks/bridge/android/manager/BridgeManagerProvider.java
+++ b/android-sdk/src/main/java/org/sagebionetworks/bridge/android/manager/BridgeManagerProvider.java
@@ -78,7 +78,7 @@ public class BridgeManagerProvider {
 
         authenticationManager = new AuthenticationManager(bridgeConfig, apiClientProvider, accountDAO, consentDAO);
         participantManager = new ParticipantRecordManager(accountDAO, authenticationManager);
-        activityManager = new ActivityManager(authenticationManager);
+        activityManager = new ActivityManager(authenticationManager, applicationContext);
         surveyManager = new SurveyManager(authenticationManager);
 
         try {

--- a/android-sdk/src/main/java/org/sagebionetworks/bridge/android/manager/dao/ActivityListDAO.java
+++ b/android-sdk/src/main/java/org/sagebionetworks/bridge/android/manager/dao/ActivityListDAO.java
@@ -1,0 +1,177 @@
+/*
+ *    Copyright 2018 Sage Bionetworks
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package org.sagebionetworks.bridge.android.manager.dao;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.gson.reflect.TypeToken;
+
+import org.sagebionetworks.bridge.rest.model.ScheduledActivity;
+import org.sagebionetworks.bridge.rest.model.ScheduledActivityListV4;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Created by TheMDP on 12/29/17.
+ */
+
+public class ActivityListDAO extends SharedPreferencesJsonDAO {
+
+    private static final String LOG_TAG = ActivityListDAO.class.getCanonicalName();
+
+    private static final TypeToken<List<ScheduledActivity>> ACTIVITY_LIST_TYPE =
+            new TypeToken<List<ScheduledActivity>>(){};
+
+    private static final String ACTIVITIES_KEY = "ACTIVITIES";
+
+    public ActivityListDAO(@NonNull Context applicationContext, @NonNull String prefsKey) {
+        super(applicationContext, prefsKey);
+    }
+
+    public void clear() {
+        sharedPreferences.edit().clear().commit();
+    }
+
+    /**
+     * Call to remove the activity from the cache
+     * @param activity to remove
+     */
+    public void removeActivity(@Nullable ScheduledActivity activity) {
+        if (activity == null) {
+            return; // nothing to remove
+        }
+
+        List<ScheduledActivity> activityList = getActivityList();
+        // Find the corresponding activity
+        ScheduledActivity activityToUpdate = findActivity(activityList, activity.getGuid());
+        // If the activity already exists, remove it
+        if (activityToUpdate != null) {
+            activityList.remove(activityToUpdate);
+        }
+        // Cache the new activity list
+        if (activityList != null) {
+            cacheActivityList(activityList);
+        }
+    }
+
+    /**
+     * Call to update a list of activities in the DAO
+     * @param activitiesToUpdate in the DAO
+     */
+    public void updateActivityList(@Nullable ScheduledActivityListV4 activitiesToUpdate) {
+        if (activitiesToUpdate == null) {
+            return; // no need to update any activities
+        }
+        updateActivityList(activitiesToUpdate.getItems());
+    }
+
+    /**
+     * Should be called when an activity is complete or when client data changes
+     * @param activityToUpdate in the DAO
+     */
+    public void updateActivity(@Nullable ScheduledActivity activityToUpdate) {
+        if (activityToUpdate == null) {
+            return; // no need to update any activities
+        }
+        updateActivityList(Collections.singletonList(activityToUpdate));
+    }
+
+    /**
+     * Call to update a list of activities in the DAO
+     * @param activitiesToUpdate in the DAO
+     */
+    public void updateActivityList(@Nullable List<ScheduledActivity> activitiesToUpdate) {
+        if (activitiesToUpdate == null || activitiesToUpdate.isEmpty()) {
+            return; // no activities to update
+        }
+
+        List<ScheduledActivity> activityList = getActivityList();
+        if (activityList == null) {
+            activityList = new ArrayList<>();
+        }
+
+        for (ScheduledActivity activity : activitiesToUpdate) {
+            // Find the corresponding activity
+            ScheduledActivity activityToUpdate = findActivity(activityList, activity.getGuid());
+            // If the activity already exists, replace it
+            if (activityToUpdate != null) {
+                activityList.remove(activityToUpdate);
+            }
+            activityList.add(activity);
+        }
+
+        // Cache the new activity list
+        cacheActivityList(activityList);
+    }
+
+    /**
+     * @param onceActivityList the map of activities, they must all be activities scheduled once
+     *                         with a null expiredOn date
+     */
+    protected void cacheActivityList(@NonNull List<ScheduledActivity> onceActivityList) {
+        setValue(ACTIVITIES_KEY, onceActivityList, ACTIVITY_LIST_TYPE);
+    }
+
+    /**
+     * @return the list of activities scheduled once
+     */
+    public @Nullable List<ScheduledActivity> getActivityList() {
+        // TODO: mdephillips 1/13/18
+        // this may fill up with many activities and parsing the json may take awhile
+        // should this be asynchronous?
+        return getValue(ACTIVITIES_KEY, ACTIVITY_LIST_TYPE);
+    }
+
+    /**
+     * @param guid of the activity to get
+     * @return the activity in the DAO with this guid
+     */
+    public @Nullable ScheduledActivity getActivity(String guid) {
+        return findActivity(getActivityList(), guid);
+    }
+
+    /**
+     * @return true if the scheduled once activities are already cached, false otherwise
+     */
+    public boolean hasActivityList() {
+        return sharedPreferences.contains(ACTIVITIES_KEY);
+    }
+
+    /**
+     * @param activityList to search
+     * @param guid of the activity to try and find
+     * @return an activity with that guid, or null if none were found
+     */
+    protected ScheduledActivity findActivity(@Nullable List<ScheduledActivity> activityList,
+                                             @Nullable String guid) {
+
+        if (guid == null || activityList == null) {
+            return null;
+        }
+        for(ScheduledActivity activity : activityList) {
+            if (guid.equals(activity.getGuid())) {
+                return activity;
+            }
+        }
+        return null;
+    }
+}

--- a/android-sdk/src/test/java/org/sagebionetworks/bridge/android/manager/ActivityManagerTest.java
+++ b/android-sdk/src/test/java/org/sagebionetworks/bridge/android/manager/ActivityManagerTest.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.bridge.android.manager;
 
+import android.content.Context;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -43,13 +45,16 @@ public class ActivityManagerTest {
 
     private ActivityManager activityManager;
 
+    @Mock
+    private Context context;
+
 
     @Before
     public void beforeTest() {
         MockitoAnnotations.initMocks(this);
 
         when(authenticationManager.getApiReference()).thenReturn(new AtomicReference<>(activitiesApi));
-        activityManager = new ActivityManager(authenticationManager);
+        activityManager = new ActivityManager(authenticationManager, context);
     }
 
     @Test

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
@@ -30,6 +30,7 @@ import org.sagebionetworks.bridge.android.BridgeConfig;
 import org.sagebionetworks.bridge.android.manager.AuthenticationManager;
 import org.sagebionetworks.bridge.android.manager.BridgeManagerProvider;
 import org.sagebionetworks.bridge.android.manager.upload.SchemaKey;
+import org.sagebionetworks.bridge.data.JsonArchiveFile;
 import org.sagebionetworks.bridge.researchstack.survey.SurveyTaskScheduleModel;
 import org.sagebionetworks.bridge.researchstack.wrapper.StorageAccessWrapper;
 import org.sagebionetworks.bridge.rest.RestUtils;
@@ -404,6 +405,7 @@ public abstract class BridgeDataProvider extends DataProvider {
         // Clear all the parts of the user data whether call is successful or not
         AppPrefs.getInstance().clear();
         StorageAccess.getInstance().removePinCode(context);
+        bridgeManagerProvider.getActivityManager().clearDAO();
 
         return dataResponse;
     }
@@ -613,22 +615,33 @@ public abstract class BridgeDataProvider extends DataProvider {
             }
         }
 
+        ScheduledActivity lastLoadedActivity = null;
         if (lastLoadedTaskGuid == null) {
-            logger.error("lastLoadedTaskGuid must be set for this task to complete and " +
-                    "set finishedOn and startedOn dates, and clientData on the bridge server");
+            logger.error("lastLoadedTaskGuid must be set for this task to complete");
+            logger.error("The activity or metadata.json will NOT be updated on bridge");
         } else {
-            // TODO: make GUID available in ScheduledActivity constructor and get rid of this gson nonsense
-            String activityJson = String.format("{\"guid\":\"%s\"}", lastLoadedTaskGuid);
-            ScheduledActivity activity = (new Gson()).fromJson(activityJson, ScheduledActivity.class);
+            lastLoadedActivity = bridgeManagerProvider
+                    .getActivityManager().getLocalActivity(lastLoadedTaskGuid);
+
+            if (lastLoadedActivity == null) {
+                lastLoadedActivity = new ScheduledActivity();
+            }
+            lastLoadedActivity.setGuid(lastLoadedTaskGuid);
             if (taskResult.getStartDate() != null) {
-                activity.setStartedOn(new DateTime(taskResult.getStartDate()));
+                lastLoadedActivity.setStartedOn(new DateTime(taskResult.getStartDate()));
             }
             if (taskResult.getEndDate() != null) {
-                activity.setFinishedOn(new DateTime(taskResult.getEndDate()));
+                lastLoadedActivity.setFinishedOn(new DateTime(taskResult.getEndDate()));
             }
-            bridgeManagerProvider.getActivityManager().updateActivity(activity).subscribe(message -> {
+            bridgeManagerProvider.getActivityManager().updateActivity(lastLoadedActivity).subscribe(message -> {
                 logger.info("Update activity success " + message);
             }, throwable -> logger.error(throwable.getLocalizedMessage()));
+        }
+
+        JsonArchiveFile metadataFile = null;
+        if (lastLoadedActivity != null) {
+            metadataFile = taskHelper.createMetaDataFile(lastLoadedActivity, getLocalDataGroups());
+            logger.debug("metadata.json has been successfully created " + metadataFile.toString());
         }
 
         if (isActivity) {
@@ -636,15 +649,16 @@ public abstract class BridgeDataProvider extends DataProvider {
             SchemaKey schemaKey = bridgeConfig.getTaskToSchemaMap().get(taskId);
 
             if (schemaKey != null) {
-                taskHelper.uploadActivityResult(schemaKey.getId(), schemaKey.getRevision(),
-                        taskResult);
+                taskHelper.uploadActivityResult(
+                        schemaKey.getId(), schemaKey.getRevision(),
+                        metadataFile, taskResult);
             } else {
                 logger.error("No schema key found for task " + taskId +
                         ", falling back to task ID as schema ID");
-                taskHelper.uploadActivityResult(taskId, taskResult);
+                taskHelper.uploadActivityResult(taskId, metadataFile, taskResult);
             }
         } else {
-            taskHelper.uploadSurveyResult(taskResult);
+            taskHelper.uploadSurveyResult(metadataFile, taskResult);
         }
     }
 

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/TaskHelper.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/TaskHelper.java
@@ -212,6 +212,7 @@ public class TaskHelper {
      * Uploads the task result to Bridge with the given schema ID and default revision 1.
      *
      * @param schemaId   schema ID for this task
+     * @param metadataFile if the caller wishes to add it to the Archive
      * @param taskResult task results
      */
     public void uploadActivityResult(@NonNull String schemaId,
@@ -226,6 +227,7 @@ public class TaskHelper {
      *
      * @param schemaId         schema ID for this task
      * @param schemaRevisionId schema revision for this task
+     * @param metadataFile if the caller wishes to add it to the Archive
      * @param taskResult       task results
      */
     public void uploadActivityResult(@NonNull String schemaId, int schemaRevisionId,
@@ -241,6 +243,7 @@ public class TaskHelper {
      * createdOn are loaded from the cache when the task was originally loaded. Task ID should match
      * the survey's identifier. See loadTask().
      *
+     * @param metadataFile if the caller wishes to add it to the Archive
      * @param taskResult task results
      */
     public void uploadSurveyResult(@Nullable JsonArchiveFile metadataFile,

--- a/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/BridgeDataProviderTest.java
+++ b/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/BridgeDataProviderTest.java
@@ -392,7 +392,7 @@ public class BridgeDataProviderTest {
         dataProvider.uploadTaskResult(context, taskResult);
 
         // verify
-        verify(taskHelper).uploadActivityResult(SCHEMA_ID, SCHEMA_REV, taskResult);
+        verify(taskHelper).uploadActivityResult(SCHEMA_ID, SCHEMA_REV, null, taskResult);
     }
 
     @Test
@@ -405,7 +405,7 @@ public class BridgeDataProviderTest {
         dataProvider.uploadTaskResult(context, taskResult);
 
         // verify
-        verify(taskHelper).uploadActivityResult(TASK_ID, taskResult);
+        verify(taskHelper).uploadActivityResult(TASK_ID, null, taskResult);
     }
 
     @Test
@@ -415,7 +415,7 @@ public class BridgeDataProviderTest {
         dataProvider.uploadTaskResult(context, taskResult);
 
         // verify
-        verify(taskHelper).uploadSurveyResult(taskResult);
+        verify(taskHelper).uploadSurveyResult(null, taskResult);
     }
 
     @Test
@@ -602,7 +602,7 @@ public class BridgeDataProviderTest {
         dataProvider.uploadTaskResult(context, taskResult);
 
         // verify
-        verify(taskHelper).uploadActivityResult(SCHEMA_ID, SCHEMA_REV, taskResult);
+        verify(taskHelper).uploadActivityResult(SCHEMA_ID, SCHEMA_REV, null, taskResult);
 
         // TODO: make GUID available in ScheduledActivity constructor and get rid of this gson nonsense
         String activityJson = String.format("{\"guid\":\"%s\"}", TASK_ID);

--- a/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/TaskHelperTest.java
+++ b/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/TaskHelperTest.java
@@ -263,15 +263,15 @@ public class TaskHelperTest {
 
         // Spy taskHelper.uploadTaskResult(). This is tested in the next test, so we don't need to
         // test it here.
-        doNothing().when(taskHelper).uploadTaskResult(any(), any());
+        doNothing().when(taskHelper).uploadTaskResult(any(), any(), any());
 
         // Execute
         TaskResult helperInput = new TaskResult(TASK_ID);
-        taskHelper.uploadActivityResult(SCHEMA_ID, helperInput);
+        taskHelper.uploadActivityResult(SCHEMA_ID, null, helperInput);
 
         // Verify backends
         verify(archiveFactory).forActivity(SCHEMA_ID);
-        verify(taskHelper).uploadTaskResult(same(helperInput), same(factoryOutput));
+        verify(taskHelper).uploadTaskResult(any(), same(helperInput), same(factoryOutput));
     }
 
     @Test
@@ -282,15 +282,15 @@ public class TaskHelperTest {
 
         // Spy taskHelper.uploadTaskResult(). This is tested in the next test, so we don't need to
         // test it here.
-        doNothing().when(taskHelper).uploadTaskResult(any(), any());
+        doNothing().when(taskHelper).uploadTaskResult(any(), any(), any());
 
         // Execute
         TaskResult helperInput = new TaskResult(TASK_ID);
-        taskHelper.uploadActivityResult(SCHEMA_ID, SCHEMA_REV, helperInput);
+        taskHelper.uploadActivityResult(SCHEMA_ID, SCHEMA_REV, null, helperInput);
 
         // Verify backends
         verify(archiveFactory).forActivity(SCHEMA_ID, SCHEMA_REV);
-        verify(taskHelper).uploadTaskResult(same(helperInput), same(factoryOutput));
+        verify(taskHelper).uploadTaskResult(any(), same(helperInput), same(factoryOutput));
     }
 
     @Test
@@ -305,15 +305,15 @@ public class TaskHelperTest {
 
         // Spy taskHelper.uploadTaskResult(). This is tested in the next test, so we don't need to
         // test it here.
-        doNothing().when(taskHelper).uploadTaskResult(any(), any());
+        doNothing().when(taskHelper).uploadTaskResult(any(), any(), any());
 
         // Execute
         TaskResult helperInput = new TaskResult(SURVEY_IDENTIFIER);
-        taskHelper.uploadSurveyResult(helperInput);
+        taskHelper.uploadSurveyResult(null, helperInput);
 
         // Verify backends
         verify(archiveFactory).forSurvey(SURVEY_GUID, SURVEY_CREATED_ON);
-        verify(taskHelper).uploadTaskResult(same(helperInput), same(factoryOutput));
+        verify(taskHelper).uploadTaskResult(any(), same(helperInput), same(factoryOutput));
     }
 
     @Test
@@ -328,15 +328,15 @@ public class TaskHelperTest {
 
         // Spy taskHelper.uploadTaskResult(). This is tested in the next test, so we don't need to
         // test it here.
-        doNothing().when(taskHelper).uploadTaskResult(any(), any());
+        doNothing().when(taskHelper).uploadTaskResult(any(), any(), any());
 
         // Execute
         TaskResult helperInput = new TaskResult(SURVEY_IDENTIFIER);
-        taskHelper.uploadSurveyResult(helperInput);
+        taskHelper.uploadSurveyResult(null, helperInput);
 
         // Verify backends
         verify(archiveFactory).forActivity(SURVEY_IDENTIFIER);
-        verify(taskHelper).uploadTaskResult(same(helperInput), same(factoryOutput));
+        verify(taskHelper).uploadTaskResult(any(), same(helperInput), same(factoryOutput));
     }
 
     @Test
@@ -351,15 +351,15 @@ public class TaskHelperTest {
 
         // Spy taskHelper.uploadTaskResult(). This is tested in the next test, so we don't need to
         // test it here.
-        doNothing().when(taskHelper).uploadTaskResult(any(), any());
+        doNothing().when(taskHelper).uploadTaskResult(any(), any(), any());
 
         // Execute
         TaskResult helperInput = new TaskResult(SURVEY_IDENTIFIER);
-        taskHelper.uploadSurveyResult(helperInput);
+        taskHelper.uploadSurveyResult(null, helperInput);
 
         // Verify backends
         verify(archiveFactory).forActivity(SURVEY_IDENTIFIER);
-        verify(taskHelper).uploadTaskResult(same(helperInput), same(factoryOutput));
+        verify(taskHelper).uploadTaskResult(any(), same(helperInput), same(factoryOutput));
     }
 
     @Test
@@ -415,7 +415,7 @@ public class TaskHelperTest {
         mockStatic(TaskAlertReceiver.class);
         when(TaskAlertReceiver.createCreateIntent(any())).thenReturn(notificationCreateIntent);
 
-        taskHelper.uploadTaskResult(taskResult, archiveBuilder);
+        taskHelper.uploadTaskResult(null, taskResult, archiveBuilder);
 
         verify(archiveFileFactory).fromResult(result1);
         verify(archiveFileFactory).fromResult(result2);


### PR DESCRIPTION
To add the metadata, we need to access the ScheduledActivity that is being uploaded.  However, up until now, we haven't stored any ScheduledActivities, and we also dispatch activities as a TaskAndSchedulesModel.

To solve these issues, I added the ActivityListDAO to the ActivityManager so that it can keep track of all the activities used in the app.  So, when uploadTaskResult() method of BridgeManager is called, we can find the ScheduledActivity that was completed based on the GUID.  

If we were successful in finding the ScheduledActivity from the ActivityListDAO during upload, we will attach "metadata.json", which is full of the same data as iOS, seen below.

{
  "taskIdentifier" : "Background Survey",
  "scheduledActivityGuid" : "dc114135-5fe3-41e2-bb48-ca7e9f0a6cdb:2018-01-04T15:58:08.124",
  "taskRunUUID" : "7957862D-B8BD-46DA-B1EC-F2855A91CADB",
  "startDate" : "2018-01-04T22:47:09.073-08:00",
  "activityLabel" : "Background Survey",
  "endDate" : "2018-01-04T22:48:24.123-08:00",
  "scheduledOn" : "2018-01-04T15:58:08.124-08:00",
  "dataGroups" : "activity_tester,test_user",
  "scheduleIdentifier" : "dc114135-5fe3-41e2-bb48-ca7e9f0a6cdb"
}
