### PR TITLE
fix multi-choice answer formatting

### DIFF
--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/survey/SurveyAnswer.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/survey/SurveyAnswer.java
@@ -1,13 +1,11 @@
 package org.sagebionetworks.bridge.researchstack.survey;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
 import org.researchstack.backbone.answerformat.AnswerFormat;
 import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.utils.FormatHelper;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -40,20 +38,21 @@ public class SurveyAnswer {
     }
   }
 
-  public static class ChoiceSurveyAnswer<T> extends SurveyAnswer {
-    public final List<T> choiceAnswers;
+  public static class ChoiceSurveyAnswer extends SurveyAnswer {
+    public final List<?> choiceAnswers;
 
-    public ChoiceSurveyAnswer(StepResult<T> stepResult) {
+    public ChoiceSurveyAnswer(StepResult<?> stepResult) {
       super(stepResult);
 
-      T result = stepResult.getResult();
+      Object result = stepResult.getResult();
       if (result instanceof List) {
-        // TODO: verify whether answer is List or array, see MultiChoiceQuestionBody
         choiceAnswers = ImmutableList.copyOf((List) result);
       } else if (result instanceof Object[]) {
+        choiceAnswers = ImmutableList.copyOf((Object[]) result);
+      } else if (result != null) {
         choiceAnswers = ImmutableList.of(result);
       } else {
-        choiceAnswers = new ArrayList<>();
+        choiceAnswers = ImmutableList.of();
       }
     }
   }

--- a/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/survey/SurveyAnswerTest.java
+++ b/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/survey/SurveyAnswerTest.java
@@ -1,0 +1,79 @@
+package org.sagebionetworks.bridge.researchstack.survey;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.researchstack.backbone.answerformat.UnknownAnswerFormat;
+import org.researchstack.backbone.result.StepResult;
+import org.researchstack.backbone.step.QuestionStep;
+
+public class SurveyAnswerTest {
+    @Test
+    public void choiceAnswers_list() {
+        StepResult stepResult = makeStepResult(ImmutableList.of("foo", "bar"));
+        SurveyAnswer.ChoiceSurveyAnswer choiceSurveyAnswer = new SurveyAnswer.ChoiceSurveyAnswer(stepResult);
+
+        List<?> answerList = choiceSurveyAnswer.choiceAnswers;
+        assertEquals(2, answerList.size());
+        assertEquals("foo", answerList.get(0));
+        assertEquals("bar", answerList.get(1));
+    }
+
+    @Test
+    public void choiceAnswers_emptyList() {
+        StepResult stepResult = makeStepResult(ImmutableList.of());
+        SurveyAnswer.ChoiceSurveyAnswer choiceSurveyAnswer = new SurveyAnswer.ChoiceSurveyAnswer(stepResult);
+        assertTrue(choiceSurveyAnswer.choiceAnswers.isEmpty());
+    }
+
+    @Test
+    public void choiceAnswers_array() {
+        StepResult stepResult = makeStepResult(new String[] { "foo", "bar" });
+        SurveyAnswer.ChoiceSurveyAnswer choiceSurveyAnswer = new SurveyAnswer.ChoiceSurveyAnswer(stepResult);
+
+        List<?> answerList = choiceSurveyAnswer.choiceAnswers;
+        assertEquals(2, answerList.size());
+        assertEquals("foo", answerList.get(0));
+        assertEquals("bar", answerList.get(1));
+    }
+
+    @Test
+    public void choiceAnswers_emptyArray() {
+        StepResult stepResult = makeStepResult(new String[] {});
+        SurveyAnswer.ChoiceSurveyAnswer choiceSurveyAnswer = new SurveyAnswer.ChoiceSurveyAnswer(stepResult);
+        assertTrue(choiceSurveyAnswer.choiceAnswers.isEmpty());
+    }
+
+    @Test
+    public void choiceAnswers_scalar() {
+        StepResult stepResult = makeStepResult("foo");
+        SurveyAnswer.ChoiceSurveyAnswer choiceSurveyAnswer = new SurveyAnswer.ChoiceSurveyAnswer(stepResult);
+
+        List<?> answerList = choiceSurveyAnswer.choiceAnswers;
+        assertEquals(1, answerList.size());
+        assertEquals("foo", answerList.get(0));
+    }
+
+    @Test
+    public void choiceAnswers_null() {
+        StepResult stepResult = makeStepResult(null);
+        SurveyAnswer.ChoiceSurveyAnswer choiceSurveyAnswer = new SurveyAnswer.ChoiceSurveyAnswer(stepResult);
+        assertTrue(choiceSurveyAnswer.choiceAnswers.isEmpty());
+    }
+
+    @SuppressWarnings({ "deprecation", "unchecked" })
+    private static StepResult makeStepResult(Object result) {
+        // We need a question step with an answer format.
+        QuestionStep step = new QuestionStep();
+        step.setAnswerFormat(new UnknownAnswerFormat());
+
+        // Make step result.
+        StepResult stepResult = new StepResult<>(step);
+        stepResult.setResult(result);
+        return stepResult;
+    }
+}


### PR DESCRIPTION
See https://sagebionetworks.jira.com/browse/AA-190

Previously, multi-answers were being doubly-nested in lists, and single-answers were being dropped entirely. This fixes the answer formatting and adds unit tests. Also removes the type information from ChoiceAnswers, since it wasn't being used, and the types didn't actually line up with anything meaningful anyway.

Testing done:
* gradlew check
* Manually tested in CRF