### PR TITLE
Don't crash when a FileResult in an archive can't be written

### DIFF
--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/TaskHelper.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/TaskHelper.java
@@ -324,7 +324,7 @@ public class TaskHelper {
                 .subscribe(() -> {
                     logger.debug("Successfully queued upload");
                     removeDataLoggerFiles(results, taskId);
-                });
+                }, t -> logger.warn("Failed to queue upload", t));
     }
 
     /**

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/factory/ArchiveFileFactory.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/factory/ArchiveFileFactory.java
@@ -162,11 +162,15 @@ public class ArchiveFileFactory {
     }
 
     @VisibleForTesting
+    @Nullable
     ByteSourceArchiveFile fromFileResult(FileResult fileResult) {
         DateTime endTime = new DateTime(fileResult.getEndDate());
 
         File file = fileResult.getFile();
-
+        if (!(file.isFile() && file.exists() && file.canRead())) {
+            return null;
+        }
+        
         int lastIndex = file.getName().lastIndexOf(".");
         String fileExtension = ".json";
         if (fileResult.getContentType().equals("video/mp4")) {

--- a/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/factory/ArchiveFileFactoryTest.java
+++ b/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/factory/ArchiveFileFactoryTest.java
@@ -110,7 +110,5 @@ public class ArchiveFileFactoryTest {
         ByteSourceArchiveFile archiveFile = archiveFileFactory.fromFileResult(fileResult);
 
         assertEquals("identifier.json", archiveFile.getFilename());
-        
-        verify(file);
     }
 }

--- a/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/factory/ArchiveFileFactoryTest.java
+++ b/researchstack-sdk/src/test/java/org/sagebionetworks/bridge/researchstack/factory/ArchiveFileFactoryTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -82,6 +83,9 @@ public class ArchiveFileFactoryTest {
 
         File file = mock(File.class);
         when(file.getName()).thenReturn(filename);
+        when(file.canRead()).thenReturn(true);
+        when(file.exists()).thenReturn(true);
+        when(file.isFile()).thenReturn(true);
 
         FileResult fileResult = new FileResult(identifier, file, contentType);
         ByteSourceArchiveFile archiveFile = archiveFileFactory.fromFileResult(fileResult);
@@ -97,10 +101,16 @@ public class ArchiveFileFactoryTest {
 
         File file = mock(File.class);
         when(file.getName()).thenReturn(filename);
+        when(file.canRead()).thenReturn(true);
+        when(file.exists()).thenReturn(true);
+        when(file.isFile()).thenReturn(true);
+        
 
         FileResult fileResult = new FileResult(identifier, file, contentType);
         ByteSourceArchiveFile archiveFile = archiveFileFactory.fromFileResult(fileResult);
 
         assertEquals("identifier.json", archiveFile.getFilename());
+        
+        verify(file);
     }
 }


### PR DESCRIPTION
* Check for existence/readability of FileResult's File
* onError handler when attempting to queue an archive for upload
* Log exceptions related to queueing an archive