### PR TITLE
Survey uploads

### DIFF
--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
@@ -126,7 +126,6 @@ public abstract class BridgeDataProvider extends DataProvider {
 
         NotificationHelper notificationHelper = NotificationHelper.
                 getInstance(bridgeManagerProvider.getApplicationContext());
-
         this.taskHelper = createTaskHelper(notificationHelper, storageAccessWrapper,
                 bridgeManagerProvider);
     }
@@ -555,15 +554,13 @@ public abstract class BridgeDataProvider extends DataProvider {
     }
 
     /**
-     * This method only returns temporary data groups that were added with the function addLocalDataGroup()
-     * This will not show you the current data groups on the user session.
-     * For that, use BridgeDataProvider.getInstance().getUserSessionInfo().getDataGroups()
-     * @return a list of data groups associated with this account. If there are no data groups,
+     * Returns a list of data groups associated with this account. If there are no data groups,
      * this method returns an empty list.
      */
     @NonNull
     public List<String> getLocalDataGroups() {
         logger.debug("Called getLocalDataGroups");
+
         return ImmutableList.copyOf(bridgeManagerProvider.getAccountDao().getDataGroups());
     }
 
@@ -609,15 +606,6 @@ public abstract class BridgeDataProvider extends DataProvider {
             return null;
         }
         return session.getSharingScope();
-    }
-
-    /**
-     * @return the current user session, returns null if the user is not signed in.
-     */
-    @Nullable
-    public UserSessionInfo getUserSessionInfo() {
-        logger.info("Called getUserSessionInfo");
-        return authenticationManager.getUserSessionInfo();
     }
 
     @Override
@@ -741,20 +729,9 @@ public abstract class BridgeDataProvider extends DataProvider {
         uploadTaskResult(null, taskResult);
     }
 
-    /**
-     * @param context can be activity or application
-     * @param taskResult from the user doing the task
-     * @param associatedSchedule linked to the task result, for creating metadata and updating schedule on bridge
-     * @param shouldUpdateAssociatedScheduleOnBridge if true, schedule will be updated,
-     *                                               if false, it will only be used to create metadata
-     */
     @SuppressLint("RxLeakedSubscription")    // upload should run as long as it needs to, no early unsubscribe
-    public void uploadTaskResult(
-            Context context,
-            @NonNull TaskResult taskResult,
-            @Nullable ScheduledActivity associatedSchedule,
-            boolean shouldUpdateAssociatedScheduleOnBridge) {
-
+    @Override
+    public void uploadTaskResult(Context context, @NonNull TaskResult taskResult) {
         // TODO: Update/Create TaskNotificationService
         logger.debug("Called uploadTaskResult");
 
@@ -767,27 +744,33 @@ public abstract class BridgeDataProvider extends DataProvider {
             }
         }
 
-        if (associatedSchedule == null) {
-            logger.warn("associatedSchedule must be set for schedule "
-                    + "to be updated on bridge, and for metadata.json to be created");
+        ScheduledActivity lastLoadedActivity = null;
+        if (lastLoadedTaskGuid == null) {
+            logger.error("lastLoadedTaskGuid must be set for this task to complete");
+            logger.error("The activity or metadata.json will NOT be updated on bridge");
         } else {
-            associatedSchedule.setGuid(lastLoadedTaskGuid);
+            lastLoadedActivity = bridgeManagerProvider
+                    .getActivityManager().getLocalActivity(lastLoadedTaskGuid);
+
+            if (lastLoadedActivity == null) {
+                lastLoadedActivity = new ScheduledActivity();
+            }
+            lastLoadedActivity.setGuid(lastLoadedTaskGuid);
             if (taskResult.getStartDate() != null) {
-                associatedSchedule.setStartedOn(new DateTime(taskResult.getStartDate()));
+                lastLoadedActivity.setStartedOn(new DateTime(taskResult.getStartDate()));
             }
             if (taskResult.getEndDate() != null) {
-                associatedSchedule.setFinishedOn(new DateTime(taskResult.getEndDate()));
+                lastLoadedActivity.setFinishedOn(new DateTime(taskResult.getEndDate()));
             }
-            if (shouldUpdateAssociatedScheduleOnBridge) {
-                bridgeManagerProvider.getActivityManager().updateActivity(associatedSchedule).subscribe(message -> {
-                    logger.info("Update activity success " + message);
-                }, throwable -> logger.error(throwable.getLocalizedMessage()));
-            }
+
+            bridgeManagerProvider.getActivityManager().updateActivity(lastLoadedActivity).subscribe(message -> {
+                logger.info("Update activity success " + message);
+            }, throwable -> logger.error(throwable.getLocalizedMessage()));
         }
 
         JsonArchiveFile metadataFile = null;
-        if (associatedSchedule != null) {
-            metadataFile = createMetaDataFile(associatedSchedule, getLocalDataGroups());
+        if (lastLoadedActivity != null) {
+            metadataFile = ArchiveUtil.createMetaDataFile(lastLoadedActivity, ImmutableList.copyOf(getLocalDataGroups()));
             logger.debug("metadata.json has been successfully created " + metadataFile.toString());
         }
 
@@ -807,28 +790,6 @@ public abstract class BridgeDataProvider extends DataProvider {
         } else {
             taskHelper.uploadSurveyResult(metadataFile, taskResult);
         }
-    }
-
-    /**
-     * Creates a metadata json archive file containing information about the schedule and user
-     * @param associatedSchedule used for metadata json file creation
-     * @param dataGroups to include in the metadata file
-     * @return JsonArchiveFile for metadata
-     */
-    protected JsonArchiveFile createMetaDataFile(
-            ScheduledActivity associatedSchedule, List<String> dataGroups) {
-        return ArchiveUtil.createMetaDataFile(
-                associatedSchedule, ImmutableList.copyOf(dataGroups));
-    }
-
-    @Override
-    public void uploadTaskResult(Context context, @NonNull TaskResult taskResult) {
-        ScheduledActivity lastLoadedActivity = null;
-        if (lastLoadedTaskGuid == null) {
-            lastLoadedActivity = bridgeManagerProvider
-                    .getActivityManager().getLocalActivity(lastLoadedTaskGuid);
-        }
-        uploadTaskResult(context, taskResult, lastLoadedActivity, true);
     }
 
     @Override

--- a/sageresearch-app-sdk/src/main/java/org/sagebionetworks/research/sageresearch/viewmodel/ResearchStackUploadArchiveFactory.kt
+++ b/sageresearch-app-sdk/src/main/java/org/sagebionetworks/research/sageresearch/viewmodel/ResearchStackUploadArchiveFactory.kt
@@ -1,0 +1,172 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright 2018  Sage Bionetworks. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission. No license is granted to the trademarks of
+ * the copyright holders even if such marks are included in this software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.sagebionetworks.research.sageresearch.viewmodel
+
+import android.os.Build
+import com.google.common.collect.ImmutableList
+import org.joda.time.DateTime
+import org.researchstack.backbone.result.Result
+import org.sagebionetworks.bridge.android.BridgeConfig
+import org.sagebionetworks.bridge.android.manager.upload.ArchiveUtil
+import org.sagebionetworks.bridge.data.Archive
+import org.sagebionetworks.bridge.data.JsonArchiveFile
+import org.sagebionetworks.bridge.researchstack.TaskHelper
+import org.sagebionetworks.bridge.researchstack.factory.ArchiveFileFactory
+import org.sagebionetworks.bridge.rest.RestUtils
+import org.sagebionetworks.research.sageresearch.dao.room.ScheduledActivityEntity
+import org.sagebionetworks.research.sageresearch.dao.room.bridgeMetadataCopy
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+/**
+ * The ResearchStackUploadArchiveFactory controls upload archive creation and allows for
+ * easy sub-classing to change the functionality of the factory.
+ */
+open class ResearchStackUploadArchiveFactory: ArchiveFileFactory() {
+
+    private val logger = LoggerFactory.getLogger(ResearchStackUploadArchiveFactory::class.java)
+
+    /**
+     * @param schedule of the task completed, if null, no metadata json file will be included
+     * @param bridgeConfig to be used for accessing schema information for the schedule
+     * @param userDataGroups the current data groups of the user
+     * @param taskResult result of running the research stack task
+     * @return a pair where first is the archive filename, and the second is the archive builder
+     */
+    open fun buildResearchStackArchive(
+        schedule: ScheduledActivityEntity?,
+        bridgeConfig: BridgeConfig,
+        userDataGroups: ImmutableList<String>,
+        userExternalId: String?,
+        taskResult: org.researchstack.backbone.result.TaskResult): Pair<String, Archive.Builder>? {
+
+        // ResearchStack tasks don't use a UUID, so just assign a random one for naming conventions
+        val rsTaskUuid = UUID.randomUUID()
+
+        var taskId = taskResult.identifier
+        var archiveFilename = taskId + rsTaskUuid
+        // If the schedule is a survey, we should create the survey archive builder
+        val builder: Archive.Builder = schedule?.activity?.survey?.let {
+            val surveyGuid = it.guid
+            var surveyCreatedOn = DateTime.now()
+            it.createdOn?.toEpochMilli()?.let { epochMillis ->
+                surveyCreatedOn = DateTime(epochMillis)
+            } ?: run {
+                logger.warn("No survey createdOn date was found for the schedule, using today's date")
+            }
+            // task is actually a survey, so use a survey archive builder
+            Archive.Builder.forSurvey(surveyGuid, surveyCreatedOn)
+        } ?: run {
+            // First check the task result for the proper task identifier, because that is historically where it is
+            // If that isn't available for whatever reason, let's assume the schedule has the correct task identifier
+            if (bridgeConfig.taskToSchemaMap[taskId] == null) {
+                taskId = schedule?.activityIdentifier()
+            }
+            val schemaKey = bridgeConfig.taskToSchemaMap[taskId] ?: run {
+                logger.error("No schema key found for task with identifier ${taskId}, skipping upload.")
+                return null
+            }
+            archiveFilename = schemaKey.id + schemaKey.revision + rsTaskUuid
+            Archive.Builder.forActivity(schemaKey.id, schemaKey.revision)
+        }
+
+        val appVersion = "version ${bridgeConfig.appVersionName}, build ${bridgeConfig.appVersion}"
+        builder.withAppVersionName(appVersion).withPhoneInfo(bridgeConfig.deviceName)
+
+        schedule?.let {
+            builder.addDataFile(createMetaDataFile(it, userDataGroups, userExternalId))
+        } ?: run {
+            logger.warn("Failed to create metadata json file for S3 upload")
+        }
+
+        // Loop through the results and add the result files to the archive
+        val flattenedResultList = TaskHelper.flattenResults(taskResult)
+        addFiles(builder, flattenedResultList, taskId)
+
+        return Pair(archiveFilename, builder)
+    }
+
+    /**
+     * Creates a metadata file archive for upload to bridge
+     * @param scheduledActivityEntity associated with the upload
+     * @param dataGroups a list of the users' data groups
+     * @param externalId if the user signed in with externalId this should be non-null, null otherwise
+     */
+    protected open fun createMetaDataFile(
+            scheduledActivityEntity: ScheduledActivityEntity,
+            dataGroups: ImmutableList<String>,
+            externalId: String?): JsonArchiveFile {
+
+        val scheduledActivity = scheduledActivityEntity.bridgeMetadataCopy()
+        val metaDataMap = ArchiveUtil.createMetaDataInfoMap(scheduledActivity, dataGroups)
+
+        // Here we can add some of our own additional metadata to the uplaod
+        externalId?.let {
+            metaDataMap["externalId"] = it
+        }
+
+        scheduledActivity.activity?.survey?.identifier?.let {
+            // Add survey identifier as taskIdentifier even though it's a survey
+            // (base implementation doesn't do this)
+            metaDataMap["taskIdentifier"] = it
+        }
+
+        metaDataMap["deviceTypeIdentifier"] =
+                "${Build.PRODUCT} ${Build.MODEL} OS v${android.os.Build.VERSION.SDK_INT}"
+
+        // Grab the end date
+        val endDate = scheduledActivity.finishedOn ?: DateTime.now()
+        val metaDataJson = RestUtils.GSON.toJson(metaDataMap)
+        return JsonArchiveFile("metadata.json", endDate, metaDataJson)
+    }
+
+    /**
+     * Can be overridden by sub-class for custom data archiving
+     * @param archiveBuilder fill this builder up with files from the flattenedResultList
+     * @param flattenedResultList read these and add them to the archiveBuilder
+     * @param taskIdentifier of the task result that contained these flattened results
+     */
+    protected open fun addFiles(
+            archiveBuilder: Archive.Builder,
+            flattenedResultList: List<Result>?,
+            taskIdentifier: String) {
+
+        flattenedResultList?.forEach { result ->
+            fromResult(result)?.let {
+                archiveBuilder.addDataFile(it)
+            } ?: run {
+                logger.error("Failed to convert Result to BridgeDataInput " + result.toString())
+            }
+        }
+    }
+}

--- a/sageresearch-app-sdk/src/main/java/org/sagebionetworks/research/sageresearch_app_sdk/inject/SageResearchAppSDKModule.java
+++ b/sageresearch-app-sdk/src/main/java/org/sagebionetworks/research/sageresearch_app_sdk/inject/SageResearchAppSDKModule.java
@@ -6,10 +6,13 @@ import android.content.Context;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
+import org.sagebionetworks.bridge.android.BridgeConfig;
 import org.sagebionetworks.bridge.android.di.BridgeApplicationScope;
 import org.sagebionetworks.bridge.android.manager.ActivityManager;
+import org.sagebionetworks.bridge.android.manager.AuthenticationManager;
 import org.sagebionetworks.bridge.android.manager.ParticipantRecordManager;
 import org.sagebionetworks.bridge.android.manager.SurveyManager;
+import org.sagebionetworks.bridge.android.manager.UploadManager;
 import org.sagebionetworks.research.presentation.perform_task.TaskResultProcessingManager.TaskResultProcessor;
 import org.sagebionetworks.research.sageresearch.dao.room.ResearchDatabase;
 import org.sagebionetworks.research.sageresearch.dao.room.ScheduledActivityEntityDao;
@@ -25,13 +28,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 
-import javax.inject.Singleton;
-
-import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.ElementsIntoSet;
-import dagger.multibindings.IntoSet;
 
 @Module(includes = {})
 public abstract class SageResearchAppSDKModule {
@@ -76,9 +75,10 @@ public abstract class SageResearchAppSDKModule {
     @BridgeApplicationScope
     static ScheduleRepository provideScheduleRepository(ScheduledActivityEntityDao scheduledActivityEntityDao,
             ScheduledRepositorySyncStateDao scheduledRepositorySyncStateDao, SurveyManager surveyManager,
-            ActivityManager activityManager, ParticipantRecordManager participantRecordManager) {
+            ActivityManager activityManager, ParticipantRecordManager participantRecordManager,
+            AuthenticationManager authManager, UploadManager uploadManager, BridgeConfig bridgeConfig) {
         LOGGER.debug("Providing ScheduleRepository");
         return new ScheduleRepository(scheduledActivityEntityDao, scheduledRepositorySyncStateDao,
-                surveyManager, activityManager, participantRecordManager);
+                surveyManager, activityManager, participantRecordManager, authManager, uploadManager, bridgeConfig);
     }
 }

--- a/sageresearch-app-sdk/src/test/java/org/sagebionetworks/research/sageresearch/viewmodel/ScheduleRepositoryTest.kt
+++ b/sageresearch-app-sdk/src/test/java/org/sagebionetworks/research/sageresearch/viewmodel/ScheduleRepositoryTest.kt
@@ -51,11 +51,15 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.sagebionetworks.bridge.android.BridgeConfig
 import org.sagebionetworks.bridge.android.manager.ActivityManager
+import org.sagebionetworks.bridge.android.manager.AuthenticationManager
 import org.sagebionetworks.bridge.android.manager.ParticipantRecordManager
 import org.sagebionetworks.bridge.android.manager.SurveyManager
+import org.sagebionetworks.bridge.android.manager.UploadManager
 import org.sagebionetworks.bridge.rest.model.Message
 import org.sagebionetworks.bridge.rest.model.ScheduledActivity
+import org.sagebionetworks.bridge.rest.model.Upload
 import org.sagebionetworks.research.domain.result.interfaces.TaskResult
 import org.sagebionetworks.research.sageresearch.dao.room.ScheduledActivityEntity
 import org.sagebionetworks.research.sageresearch.dao.room.ScheduledActivityEntityDao
@@ -83,6 +87,15 @@ class ScheduleRepositoryTest {
     private lateinit var participantRecordManager: ParticipantRecordManager
 
     @Mock
+    private lateinit var authManager: AuthenticationManager
+
+    @Mock
+    private lateinit var uploadManager: UploadManager
+
+    @Mock
+    private lateinit var bridgeConfig: BridgeConfig
+
+    @Mock
     private lateinit var scheduledActivityEntityDao: ScheduledActivityEntityDao
 
     @Mock
@@ -95,7 +108,8 @@ class ScheduleRepositoryTest {
         MockitoAnnotations.initMocks(this)
         scheduleRepository = spy(
                 ScheduleRepository(scheduledActivityEntityDao, scheduledRepositorySyncStateDao,
-                        surveyManager, activityManager, participantRecordManager))
+                        surveyManager, activityManager, participantRecordManager,
+                        authManager, uploadManager, bridgeConfig))
     }
 
     @Ignore


### PR DESCRIPTION
Reverted my BridgeDataProvider in favor of referencing the upload manager directly per our other approaches.  I also moved ResearchStack TaskResult archiving functionality to its on class and var which makes it easy to add custom functionality in mPower, like what I need to do for the StudyBurst task.