### PR TITLE
AA-363

### DIFF
--- a/sageresearch-app-sdk/src/androidTest/java/org/sagebionetworks/research/sageresearch/viewmodel/ReportRepositoryTests.kt
+++ b/sageresearch-app-sdk/src/androidTest/java/org/sagebionetworks/research/sageresearch/viewmodel/ReportRepositoryTests.kt
@@ -38,6 +38,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import org.joda.time.DateTimeZone
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 
 import org.junit.Before
@@ -55,6 +56,7 @@ import org.sagebionetworks.research.sageresearch.dao.room.ReportRepository
 import org.sagebionetworks.research.sageresearch.dao.room.entityCopy
 import org.sagebionetworks.research.sageresearch.dao.room.mapValue
 import org.sagebionetworks.research.sageresearch.extensions.toJodaLocalDate
+import org.sagebionetworks.research.sageresearch.viewmodel.TaskResultHelper.Companion
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.ZoneId
@@ -117,6 +119,21 @@ class ReportRepositoryTests: RoomTestHelper() {
         assertNotNull(clientData)
         clientData?.let {
             assertMapEquals(TaskResultHelper.expectedSurveyClientDataMap, it)
+        }
+    }
+
+    @Test
+    fun test_buildClientDataExclusions() {
+        reportRepository.resultExclusionList.add(TaskResultHelper.intAnswerResultId)
+        val clientData = reportRepository.buildClientData(TaskResultHelper.surveyTaskResult())
+        assertNotNull(clientData)
+        clientData?.let {
+            assertNull(it[TaskResultHelper.intAnswerResultId])
+        }
+        val clientDataRs = reportRepository.buildClientData(TaskResultHelper.researchStackSurveyTaskResult())
+        assertNotNull(clientDataRs)
+        clientDataRs?.let {
+            assertNull(it[TaskResultHelper.intAnswerResultId])
         }
     }
 

--- a/sageresearch-app-sdk/src/main/java/org/sagebionetworks/research/sageresearch/dao/room/ReportRepository.kt
+++ b/sageresearch-app-sdk/src/main/java/org/sagebionetworks/research/sageresearch/dao/room/ReportRepository.kt
@@ -95,7 +95,8 @@ open class ReportRepository constructor(
     /**
      * @property resultExclusionList Allows for excluding a specific result identifier from the
      *                               clientDataAnswerMap so it will not show up in a report.
-     *
+     *                               This can be used to make sure sensitive information isn't stored in a report
+     *                               Or to simply make the size of the report smaller.
      */
     open val resultExclusionList: MutableList<String> = mutableListOf()
 

--- a/sageresearch-app-sdk/src/main/java/org/sagebionetworks/research/sageresearch/dao/room/ReportRepository.kt
+++ b/sageresearch-app-sdk/src/main/java/org/sagebionetworks/research/sageresearch/dao/room/ReportRepository.kt
@@ -93,6 +93,13 @@ open class ReportRepository constructor(
     open val reportPageSizeV4: Int get() = 50
 
     /**
+     * @property resultExclusionList Allows for excluding a specific result identifier from the
+     *                               clientDataAnswerMap so it will not show up in a report.
+     *
+     */
+    open val resultExclusionList: MutableList<String> = mutableListOf()
+
+    /**
      * @property reportSingletonDate used when doing read/write on singleton category reports
      */
     val reportSingletonDate: Instant = Instant.EPOCH
@@ -449,7 +456,11 @@ open class ReportRepository constructor(
      * @return the client data built for this task result as a json string
      */
     open fun buildClientData(taskResult: TaskResult): Map<String, Any>? {
-        return taskResult.clientDataAnswerMap()
+        val clientData = taskResult.clientDataAnswerMap()
+        // Exclude any results that should not make it into a report
+        return clientData.filter {
+            !resultExclusionList.contains(it.key)
+        }
     }
 
     /**
@@ -458,7 +469,11 @@ open class ReportRepository constructor(
      * @return the client data built for this task result as a json string
      */
     open fun buildClientData(rsTaskResult: org.researchstack.backbone.result.TaskResult): Map<String, Any>? {
-        return rsTaskResult.clientDataAnswerMap()
+        val clientData = rsTaskResult.clientDataAnswerMap()
+        // Exclude any results that should not make it into a report
+        return clientData.filter {
+            !resultExclusionList.contains(it.key)
+        }
     }
 
     /**


### PR DESCRIPTION
Added tested feature for excluding a result id from reports.  This is used in mPower to hide the "What was your previous email used in mPower 1" from reports.