### PR TITLE
reportRepoTests

### DIFF
--- a/sageresearch-app-sdk/src/androidTest/java/org/sagebionetworks/research/sageresearch/viewmodel/ReportRepositoryTests.kt
+++ b/sageresearch-app-sdk/src/androidTest/java/org/sagebionetworks/research/sageresearch/viewmodel/ReportRepositoryTests.kt
@@ -89,11 +89,7 @@ class ReportRepositoryTests: RoomTestHelper() {
 
         val bridgeGson = EntityTypeConverters().bridgeGson
     }
-
-    @Rule
-    @JvmField
-    var testSchedulerRule = TestSchedulerRule()
-
+    
     lateinit var reportRepository: MockReportRepository
     @Mock
     lateinit var participantManager: ParticipantRecordManager
@@ -459,5 +455,8 @@ class ReportRepositoryTests: RoomTestHelper() {
 
         // Make sure that even the async scheduler runs on the main threads
         override val asyncScheduler: Scheduler get() = AndroidSchedulers.mainThread()
+
+        // Make sure that even the async scheduler runs on the main threads
+        override val asyncSchedulerV1: rx.Scheduler get() = rx.android.schedulers.AndroidSchedulers.mainThread()
     }
 }


### PR DESCRIPTION
Fixed threading issues for ReportRepositoryTests.  Also reverted the doOnNext, as the change isn't verified on a device in a real situation where as concatWith has been.