### PR TITLE
Update SQLCipher for compliance with Play Store requirement for 64-bit

### DIFF
--- a/researchstack-sdk/build.gradle
+++ b/researchstack-sdk/build.gradle
@@ -37,6 +37,9 @@ dependencies {
   api project (':backbone'), {
     exclude group: 'joda-time', module: 'joda-time'
   }
+  // Need to replace backbone's version with a 64-bit binary
+  implementation 'net.zetetic:android-database-sqlcipher:4.2.0@aar'
+
   api project(":android-sdk") // to export BridgeApplication
 
   implementation "com.android.support:appcompat-v7:${support_library_version}"


### PR DESCRIPTION
* Bring in 64-bit library to comply with Play store's 64-bit requirement