### PR TITLE
Refactored sign up function to a more flexible implementation.

### DIFF
--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
@@ -348,17 +348,18 @@ public abstract class BridgeDataProvider extends DataProvider {
 
     @NonNull
     public Observable<DataResponse> signUp(@NonNull SignUp signUp) {
-        // saving email to user object should exist elsewhere.
-        // Save email to user object.
+        logger.debug("Called signUp with open ended sign up data model");
 
-        return signUp(signUp.getEmail(), signUp.getPassword());
+        return authenticationManager
+                .signUp(signUp)
+                .andThen(SUCCESS_DATA_RESPONSE);
     }
 
     @NonNull
     public Observable<DataResponse> signUp(@NonNull String email, @Nullable String password) {
         checkNotNull(email);
 
-        logger.debug("Called signUp");
+        logger.debug("Called signUp with email and password");
 
         return authenticationManager
                 .signUp(email, password)

--- a/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
+++ b/researchstack-sdk/src/main/java/org/sagebionetworks/bridge/researchstack/BridgeDataProvider.java
@@ -348,7 +348,15 @@ public abstract class BridgeDataProvider extends DataProvider {
 
     @NonNull
     public Observable<DataResponse> signUp(@NonNull SignUp signUp) {
-        logger.debug("Called signUp with open ended sign up data model");
+        // saving email to user object should exist elsewhere.
+        // Save email to user object.
+
+        return signUp(signUp.getEmail(), signUp.getPassword());
+    }
+
+    @NonNull
+    public Observable<DataResponse> signUpPhone(@NonNull SignUp signUp) {
+        logger.debug("Called signUpPhone");
 
         return authenticationManager
                 .signUp(signUp)
@@ -359,7 +367,7 @@ public abstract class BridgeDataProvider extends DataProvider {
     public Observable<DataResponse> signUp(@NonNull String email, @Nullable String password) {
         checkNotNull(email);
 
-        logger.debug("Called signUp with email and password");
+        logger.debug("Called signUp");
 
         return authenticationManager
                 .signUp(email, password)


### PR DESCRIPTION
MP2 has the requirement to add data groups when a user signs up with a phone number, but unfortunately, all the available functions in BridgeDataProvider for phone number take the Phone class as a parameter.  This does not allow for any data groups to be attached to the SignUp model.

I'm open to suggestions that fix the issue, but this PR has my first draft solution for this by adding a new function that can do phone sign up and also allow the developer to provide data groups.

